### PR TITLE
fix bufferevent double free bug

### DIFF
--- a/src/session/inbound.c
+++ b/src/session/inbound.c
@@ -369,7 +369,7 @@ static void on_local_event(struct bufferevent *bev, short events, void *ctx)
 		pgs_session_error(session,
 				  "Error from bufferevent: on_local_event");
 	if (events & (BEV_EVENT_EOF | BEV_EVENT_ERROR)) {
-		bufferevent_free(bev);
+		//bufferevent_free(bev);
 		PGS_FREE_SESSION(session);
 	}
 }

--- a/src/session/inbound.c
+++ b/src/session/inbound.c
@@ -369,7 +369,6 @@ static void on_local_event(struct bufferevent *bev, short events, void *ctx)
 		pgs_session_error(session,
 				  "Error from bufferevent: on_local_event");
 	if (events & (BEV_EVENT_EOF | BEV_EVENT_ERROR)) {
-		//bufferevent_free(bev);
 		PGS_FREE_SESSION(session);
 	}
 }


### PR DESCRIPTION
i test on ios 
bufferevent_free(bev) will call in next  PGS_FREE_SESSION(session);
bev double free